### PR TITLE
test: add unit tests for main functions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.32.3
 PyNaCl==1.5.0
+pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,49 @@
+import json
+import os
+from unittest.mock import patch
+
+from main import escape_string, load_published_ids, save_published_ids
+
+
+class TestEscapeString:
+    def test_plain_text_unchanged(self):
+        # escape_string is a passthrough in this project (not implemented yet)
+        assert escape_string("Hello World") == "Hello World"
+
+    def test_empty_string(self):
+        assert escape_string("") == ""
+
+    def test_returns_string(self):
+        assert isinstance(escape_string("test"), str)
+
+
+class TestLoadPublishedIds:
+    def test_returns_list_from_env(self):
+        ids = [1, 2, 3]
+        with patch.dict(os.environ, {"PUBLISHED_IDS": json.dumps(ids)}):
+            result = load_published_ids()
+        assert result == ids
+
+    def test_returns_empty_list_when_env_missing(self):
+        env = {k: v for k, v in os.environ.items() if k != "PUBLISHED_IDS"}
+        with patch.dict(os.environ, env, clear=True):
+            result = load_published_ids()
+        assert result == []
+
+    def test_returns_empty_list_on_invalid_json(self):
+        with patch.dict(os.environ, {"PUBLISHED_IDS": "not-json"}):
+            result = load_published_ids()
+        assert result == []
+
+
+class TestSavePublishedIds:
+    def test_calls_update_github_variable(self):
+        ids = [10, 20, 30]
+        with patch("main.update_github_variable") as mock_update:
+            save_published_ids(ids)
+        mock_update.assert_called_once_with("PUBLISHED_IDS", json.dumps(ids))
+
+    def test_saves_empty_list(self):
+        with patch("main.update_github_variable") as mock_update:
+            save_published_ids([])
+        mock_update.assert_called_once_with("PUBLISHED_IDS", "[]")


### PR DESCRIPTION
## Summary

- Add `pytest` to `requirements.txt`
- Add `tests/test_main.py` with 8 unit tests covering: `escape_string`, `load_published_ids`, `save_published_ids`
- Env variables and GitHub API calls mocked via `unittest.mock`

## Test plan
- [ ] Run `.venv/bin/python -m pytest tests/ -v` — all 8 tests pass